### PR TITLE
fix: Link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # openapi-generation-tests
 [![Tests](https://github.com/speakeasy-api/openapi-generation-tests/actions/workflows/test.yml/badge.svg)](https://github.com/speakeasy-api/openapi-generation-tests/actions/workflows/test.yml)
 
-This repo contains the test suites for [Speakeasy's OpenAPI SDK Generator](https://speakeasyapi.dev/docs/using-speakeasy/create-client-sdks/intro/). It shows the testing we run internally on SDKs generated from an OpenAPI document that contains a large range of potential API shapes to ensure our generation covers all the use cases we support with our SDKs.
+This repo contains the test suites for [Speakeasy's OpenAPI SDK Generator](https://www.speakeasyapi.dev/docs/create-client-sdks). It shows the testing we run internally on SDKs generated from an OpenAPI document that contains a large range of potential API shapes to ensure our generation covers all the use cases we support with our SDKs.


### PR DESCRIPTION
The link to generation docs was broken, this change fixes it.